### PR TITLE
Silly refactor for more idiomatic Rust style

### DIFF
--- a/contracts/dkg_coordinator/src/bls.rs
+++ b/contracts/dkg_coordinator/src/bls.rs
@@ -88,14 +88,16 @@ impl<'de> Deserialize<'de> for G2Element {
     {
         let s = String::deserialize(deserializer)?;
         let decoded = BASE64_STANDARD.decode(&s).map_err(D::Error::custom)?;
-        if decoded.len() != G2_ELEMENT_BYTE_LENGTH {
-            return Err(D::Error::custom(format!(
-                "Invalid length for G2Element: expected {}, got {}",
-                G2_ELEMENT_BYTE_LENGTH,
-                decoded.len()
-            )));
+        match decoded.len() {
+            G2_ELEMENT_BYTE_LENGTH => Ok(G2Element(decoded)),
+            len => Err(D::Error::custom(
+                format_args!(
+                    "Invalid length for G2Element: expected {}, got {}",
+                    G2_ELEMENT_BYTE_LENGTH, len
+                )
+                .to_string(),
+            )),
         }
-        Ok(G2Element(decoded))
     }
 }
 
@@ -116,14 +118,16 @@ impl<'de> Deserialize<'de> for Scalar {
     {
         let s = String::deserialize(deserializer)?;
         let decoded = BASE64_STANDARD.decode(&s).map_err(D::Error::custom)?;
-        if decoded.len() != SCALAR_LENGTH {
-            return Err(D::Error::custom(format!(
-                "Invalid length for Scalar: expected {}, got {}",
-                SCALAR_LENGTH,
-                decoded.len()
-            )));
+        match decoded.len() {
+            SCALAR_LENGTH => Ok(Scalar(decoded)),
+            len => Err(D::Error::custom(
+                format_args!(
+                    "Invalid length for Scalar: expected {}, got {}",
+                    SCALAR_LENGTH, len
+                )
+                .to_string(),
+            )),
         }
-        Ok(Scalar(decoded))
     }
 }
 


### PR DESCRIPTION
Cheers! Just looking around and sending some love.

- Replaced `if` statements with `match` for checking decoded lengths in `G2Element` and `Scalar`.
- Used `format_args!` instead of `format!` for error message construction to avoid unnecessary memory allocations.