### PR TITLE
Refactor: Use explicit type suffixes for clarity in DKG test module

### DIFF
--- a/dkg/src/peer.rs
+++ b/dkg/src/peer.rs
@@ -581,12 +581,12 @@ mod test {
 
         // Create a DKG session.
         let nodes = create_nodes(vec![
-            (public_key_1, 4 as u16),
-            (public_key_2, 5 as u16),
-            (public_key_3, 7 as u16),
+            (public_key_1, 4_u16),
+            (public_key_2, 5_u16),
+            (public_key_3, 7_u16),
         ]);
         assert!(dkg_coordinator_1
-            .create_session(6 as u16, nodes)
+            .create_session(6_u16, nodes)
             .await
             .is_ok());
 


### PR DESCRIPTION
Updated the type annotations from `as u16` to `_u16` suffixes for consistency and improved readability in the `create_nodes` function and `create_session` call within the test module of `peer.rs`. This change ensures type clarity and aligns with best practices for type suffixes in Rust.