### PR TITLE
Refactored dkg_coordinator/execute.rs

### DIFF
--- a/contracts/dkg_coordinator/src/execute.rs
+++ b/contracts/dkg_coordinator/src/execute.rs
@@ -6,7 +6,7 @@ pub mod execute {
     use crate::state::DKG_SESSION;
 
     use primitives::{
-        bls::{Confirmation, DKGSession, Message, Node, Nodes, Phase},
+        bls::{Confirmation, DKGSession, Message, Node, Nodes, PartyId, Phase},
         utils::{calculate_total_weight, filter_known_pk, verify_signature, HasSender},
     };
 
@@ -75,7 +75,7 @@ pub mod execute {
             ItemType::Message => {
                 // Check if message is a duplicate
                 if session.phase < Phase::Phase2
-                    && is_duplicate_sender(&session.messages, &item.get_sender().to_string())
+                    && is_duplicate_sender(&session.messages, item.get_sender())
                 {
                     return Err(ExecuteError::DuplicateMessage);
                 }
@@ -83,7 +83,7 @@ pub mod execute {
             ItemType::Confirmation => {
                 // Check if confirmation is a duplicate
                 if session.phase < Phase::Phase3
-                    && is_duplicate_sender(&session.confirmations, &item.get_sender().to_string())
+                    && is_duplicate_sender(&session.confirmations, item.get_sender())
                 {
                     return Err(ExecuteError::DuplicateConfirmation);
                 }
@@ -176,9 +176,7 @@ pub mod execute {
         result.map_err(|e| e.into())
     }
 
-    fn is_duplicate_sender<T: HasSender>(items: &[T], sender: &str) -> bool {
-        items
-            .iter()
-            .any(|item| item.get_sender().to_string() == sender)
+    fn is_duplicate_sender<T: HasSender>(items: &[T], sender: &PartyId) -> bool {
+        items.iter().any(|item| item.get_sender() == sender)
     }
 }

--- a/dkg/src/peer.rs
+++ b/dkg/src/peer.rs
@@ -475,7 +475,7 @@ mod test {
             &self,
             confirmation: Confirmation,
             signature: blst::min_sig::Signature,
-            pk: blst::min_sig::PublicKey,
+            _pk: blst::min_sig::PublicKey,
         ) -> Result<Confirmation, DKGError> {
             let mut session = self.session.lock().unwrap();
             let session = session.as_mut().unwrap();
@@ -585,10 +585,7 @@ mod test {
             (public_key_2, 5_u16),
             (public_key_3, 7_u16),
         ]);
-        assert!(dkg_coordinator_1
-            .create_session(6_u16, nodes)
-            .await
-            .is_ok());
+        assert!(dkg_coordinator_1.create_session(6_u16, nodes).await.is_ok());
 
         // Message phase.
         assert_eq!(


### PR DESCRIPTION
Refactor execute.rs: Replace `item_type` `string` with `ItemType` enum and optimize duplicate checks

- Introduced `ItemType` enum to replace `item_type` string parameter in `verify_and_check_duplicate`.
- Added `map_error` function for cleaner error mapping.
- Implemented `is_duplicate_sender` function to simplify duplicate checks.
- Refactored test in `peer.rs` to remove unused variable.
- Improved code readability and maintainability.
